### PR TITLE
Add #extract_into_object to DSL for updating objects.

### DIFF
--- a/lib/kartograph/dsl.rb
+++ b/lib/kartograph/dsl.rb
@@ -40,6 +40,19 @@ module Kartograph
         Sculptor.new(loaded, @kartograph_map).sculpt(scope)
       end
 
+      def extract_into_object(object, content, scope, loader = Kartograph.default_loader)
+        loaded = loader.load(content)
+
+        retrieve_root_key(scope, :singular) do |root_key|
+          # Reassign loaded if a root key exists
+          loaded = loaded[root_key]
+        end
+
+        sculptor = Sculptor.new(loaded, @kartograph_map)
+        sculptor.sculpted_object = object
+        sculptor.sculpt(scope)
+      end
+
       def extract_collection(content, scope, loader = Kartograph.default_loader)
         loaded = loader.load(content)
 

--- a/lib/kartograph/sculptor.rb
+++ b/lib/kartograph/sculptor.rb
@@ -11,14 +11,25 @@ module Kartograph
       map.properties
     end
 
+    def sculpted_object
+      # Fallback initialization of the object we're extracting into
+      @sculpted_object ||= map.mapping.new
+    end
+
+    # Set this to pass in an object to extract into. Must
+    # @param object must be of the same class as the map#mapping
+    def sculpted_object=(object)
+      raise ArgumentError unless object.is_a?(map.mapping)
+
+      @sculpted_object = object
+    end
+
     def sculpt(scope = nil)
       return nil if @object.nil?
 
-      # Initializing the object we're coercing so we can set attributes on it
-      coerced = map.mapping.new
       scoped_properties = scope ? properties.filter_by_scope(scope) : properties
 
-      scoped_properties.each_with_object(coerced) do |property, mutable|
+      scoped_properties.each_with_object(sculpted_object) do |property, mutable|
         setter_method = "#{property.name}="
         value = property.value_from(object, scope)
         mutable.send(setter_method, value)

--- a/spec/lib/kartograph/dsl_spec.rb
+++ b/spec/lib/kartograph/dsl_spec.rb
@@ -122,6 +122,21 @@ describe Kartograph::DSL do
     end
   end
 
+  describe '.extract_into_object' do
+    include_context 'DSL Objects'
+    let(:json) do
+      { id: 1337, name: 'Paul the octopus' }
+    end
+
+    it 'returns a populated object from a JSON representation' do
+      object = DummyUser.new
+      mapped.extract_into_object(object, json.to_json, :read)
+
+      expect(object.id).to eq(1337)
+      expect(object.name).to eq('Paul the octopus')
+    end
+  end
+
   describe '.extract_collection' do
     include_context 'DSL Objects'
     let(:json) do

--- a/spec/lib/kartograph/sculptor_spec.rb
+++ b/spec/lib/kartograph/sculptor_spec.rb
@@ -13,6 +13,40 @@ describe Kartograph::Sculptor do
     end
   end
 
+  describe '#sculpted_object=' do
+    context 'objects that are not the mapping class' do
+      it 'raises an error' do
+        hash = {}
+        map = double(Kartograph::Map, mapping: Hash)
+
+        sculptor = Kartograph::Sculptor.new(hash, map)
+
+        expect {
+          sculptor.sculpted_object = ""
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'sets the sculpted_object' do
+      hash = {}
+      map = double(Kartograph::Map, mapping: Hash)
+
+      sculptor = Kartograph::Sculptor.new(hash, map)
+      sculptor.sculpted_object = hash
+      expect(sculptor.sculpted_object).to be hash
+    end
+  end
+
+  describe '#sculpted_object' do
+    it 'initializes the mapping class' do
+      hash = {}
+      map = double(Kartograph::Map, mapping: Hash)
+
+      sculptor = Kartograph::Sculptor.new(hash, map)
+      expect(sculptor.sculpted_object).to be_kind_of(Hash)
+    end
+  end
+
   describe '#sculpt' do
     let(:map) { Kartograph::Map.new }
     let(:object) { { 'id' => 343, 'name' => 'Guilty Spark', 'email_address' => 'guilty@bungie.net' } }
@@ -38,6 +72,15 @@ describe Kartograph::Sculptor do
         expect(sculpted.id).to eq(object['id'])
         expect(sculpted.name).to eq(object['name'])
         expect(sculpted.email).to eq(object['email_address'])
+      end
+
+      it 'sculpts into a provided object' do
+        sculptor = Kartograph::Sculptor.new(object, map)
+        dummy = DummyUser.new
+        sculptor.sculpted_object = dummy
+        sculpted = sculptor.sculpt
+
+        expect(sculpted).to be dummy
       end
     end
 


### PR DESCRIPTION
This is part of a solution for some of the confusion around Kartograph creating new instances of objects for return values. Using this helper, a target object can be provided to extract the response into. Resource Kit and/or Droplet Kit will have to be updated to use this method.

The goal is:
```ruby
client = DropletKit::Client.new(access_token: token)
droplet = DropletKit::Droplet.new(name: 'example', region: 'nyc3', size: '1gb', image: 'ubuntu-14-04-x64', ssh_keys: ["654321", "123456"])
droplet.id # => nil
client.droplets.create(droplet)
droplet.id # => 12345
```

This is an alternative to https://github.com/digitalocean/droplet_kit/pull/49