### PR TITLE
Add the ability to specify properties as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,44 @@ class UserMapping
 end
 ```
 
+### Optional values
+
+By default, Kartograph will serialize the object and give any attributes without
+values a value of `null`. This could cause problems for some API's that expect
+default values to be omitted from a request in order to be ignored.
+
+Attributes can be marked as optional, meaning they will not be included in the
+representation if no value is given for that attribute or if the value is nil.
+
+```ruby
+class UserMapping
+  include Kartograph::DSL
+
+  kartograph do
+    mapping User
+    property :name, scopes: [:create, :update]
+    property :age, scopes: [:create]
+  end
+end
+
+class OptionalUserMapping
+  include Kartograph::DSL
+
+  kartograph do
+    mapping User
+    property :name, scopes: [:create, :update]
+    property :age, scopes: [:create], optional: true
+  end
+end
+
+user = User.new(name: 'Bobby Tables', age: nil)
+
+default_json = UserMapping.representation_for(:create, user)
+# => "{\"name\":\"Bobby Tables\",\"age\":null}"
+optional_json = OptionalUserMapping.representation_for(:create, user)
+# => "{\"name\":\"Bobby Tables\"}"
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/digitaloceancloud/kartograph/fork )

--- a/lib/kartograph/artist.rb
+++ b/lib/kartograph/artist.rb
@@ -25,7 +25,7 @@ module Kartograph
       scoped_properties.each_with_object({}) do |property, mapped|
         raise ArgumentError, "#{object} does not respond to #{property.name}, so we can't map it" unless object.respond_to?(property.name)
 
-        mapped[property.key] = property.value_for(object, scope)
+        mapped[property.key] = property.value_for(object, scope) unless property.value_for(object, scope).nil? && property.optional?
       end
     end
   end

--- a/lib/kartograph/property.rb
+++ b/lib/kartograph/property.rb
@@ -43,6 +43,10 @@ module Kartograph
       !!options[:plural]
     end
 
+    def optional?
+      !!options[:optional]
+    end
+
     def dup
       Property.new(name, options.dup).tap do |property|
         property.map = map.dup if self.map

--- a/spec/lib/kartograph/artist_spec.rb
+++ b/spec/lib/kartograph/artist_spec.rb
@@ -47,6 +47,19 @@ describe Kartograph::Artist do
       end
     end
 
+    context 'for a property marked as optional' do
+      it 'skips adding the key if the value is nil' do
+        object     = double('object', hello: 'world', foo: nil)
+        properties << Kartograph::Property.new(:hello, scopes: :create)
+        properties << Kartograph::Property.new(:foo, scopes: :create, optional: true)
+
+        artist = Kartograph::Artist.new(object, map)
+        masterpiece = artist.draw(:create)
+
+        expect(masterpiece).to eq(hello: 'world')
+      end
+    end
+
     context 'for filtered drawing' do
       it 'only returns the scoped properties' do
         object     = double('object', hello: 'world', foo: 'bar')


### PR DESCRIPTION
This removes null fields when the objects are converted into the JSON representation for optional properties. This is useful for APIs where a property being optional either means a key is present in the request body or it isn't. 

Let me know if I should add more test cases for this. 
