### PR TITLE
Add support for drawing hash representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ user = User.new(name: 'Bobby Tables')
 json_for_create = UserMapping.representation_for(:create, user)
 ```
 
+### Rendering Objects or Collections as Hashes
+
+```ruby
+user = User.new(name: 'PB Jelly')
+users = [user]
+
+hash = UserMapping.hash_for(:read, user)
+hash_collection = UserMapping.hash_collection_for(:read, user)
+```
+
 ### Rendering Collections as JSON
 
 ```ruby

--- a/lib/kartograph/dsl.rb
+++ b/lib/kartograph/dsl.rb
@@ -15,18 +15,25 @@ module Kartograph
         @kartograph_map
       end
 
-      def representation_for(scope, object, dumper = Kartograph.default_dumper)
-        drawed = Artist.new(object, @kartograph_map).draw(scope)
-
-        dumper.dump(prepend_root_key(scope, :singular, drawed))
+      def hash_for(scope, object)
+        drawn_object = Artist.new(object, @kartograph_map).draw(scope)
+        prepend_root_key(scope, :singular, drawn_object)
       end
 
-      def represent_collection_for(scope, objects, dumper = Kartograph.default_dumper)
-        drawed_objects = objects.map do |object|
+      def hash_collection_for(scope, objects)
+        drawn_objects = objects.map do |object|
           Artist.new(object, @kartograph_map).draw(scope)
         end
 
-        dumper.dump(prepend_root_key(scope, :plural, drawed_objects))
+        prepend_root_key(scope, :plural, drawn_objects)
+      end
+
+      def representation_for(scope, object, dumper = Kartograph.default_dumper)
+        dumper.dump(hash_for(scope, object))
+      end
+
+      def represent_collection_for(scope, objects, dumper = Kartograph.default_dumper)
+        dumper.dump(hash_collection_for(scope, objects))
       end
 
       def extract_single(content, scope, loader = Kartograph.default_loader)

--- a/lib/kartograph/dsl.rb
+++ b/lib/kartograph/dsl.rb
@@ -15,11 +15,21 @@ module Kartograph
         @kartograph_map
       end
 
+      # Returns a hash representation of the object based on the mapping
+      #
+      # @param scope [Symbol] the scope of the mapping
+      # @param object the object to be mapped
+      # @return [Hash, Array]
       def hash_for(scope, object)
         drawn_object = Artist.new(object, @kartograph_map).draw(scope)
         prepend_root_key(scope, :singular, drawn_object)
       end
 
+      # Returns a hash representation of the collection of objects based on the mapping
+      #
+      # @param scope [Symbol] the scope of the mapping
+      # @params objects [Array] the array of objects to be mapped
+      # @return [Hash, Array]
       def hash_collection_for(scope, objects)
         drawn_objects = objects.map do |object|
           Artist.new(object, @kartograph_map).draw(scope)

--- a/lib/kartograph/property.rb
+++ b/lib/kartograph/property.rb
@@ -20,7 +20,7 @@ module Kartograph
     end
 
     def key
-      options[:key] || name
+      (options[:key] || name).to_s
     end
 
     def value_for(object, scope = nil)
@@ -31,7 +31,7 @@ module Kartograph
 
     def value_from(object, scope = nil)
       return if object.nil?
-      value = object.has_key?(key) ? object[key] : object[key.to_s]
+      value = object.has_key?(key) ? object[key] : object[key.to_sym]
       map ? sculpt_value(value, scope) : value
     end
 

--- a/lib/kartograph/version.rb
+++ b/lib/kartograph/version.rb
@@ -1,4 +1,4 @@
 module Kartograph
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end
 

--- a/spec/lib/kartograph/artist_spec.rb
+++ b/spec/lib/kartograph/artist_spec.rb
@@ -24,7 +24,7 @@ describe Kartograph::Artist do
       artist = Kartograph::Artist.new(object, map)
       masterpiece = artist.draw
 
-      expect(masterpiece).to include(hello: 'world')
+      expect(masterpiece).to include('hello' => 'world')
     end
 
     it 'raises for a property that the object does not have' do
@@ -43,7 +43,7 @@ describe Kartograph::Artist do
         artist = Kartograph::Artist.new(object, map)
         masterpiece = artist.draw
 
-        expect(masterpiece).to include(hola: 'world')
+        expect(masterpiece).to include('hola' => 'world')
       end
     end
 
@@ -56,7 +56,7 @@ describe Kartograph::Artist do
         artist = Kartograph::Artist.new(object, map)
         masterpiece = artist.draw(:read)
 
-        expect(masterpiece).to eq(hello: 'world')
+        expect(masterpiece).to eq('hello' => 'world')
       end
 
       context 'on nested properties' do
@@ -74,7 +74,7 @@ describe Kartograph::Artist do
           artist = Kartograph::Artist.new(object, map)
           masterpiece = artist.draw(:read)
 
-          expect(masterpiece).to eq(child: { foo: child.foo })
+          expect(masterpiece).to eq('child' => { 'foo' => child.foo })
         end
       end
     end

--- a/spec/lib/kartograph/property_spec.rb
+++ b/spec/lib/kartograph/property_spec.rb
@@ -9,7 +9,7 @@ describe Kartograph::Property do
       property = Kartograph::Property.new(name, options)
       expect(property.name).to eq(name)
       expect(property.options).to eq(options)
-      expect(property.key).to eq(:hey)
+      expect(property.key).to eq('hey')
     end
 
     context 'with a key' do
@@ -89,7 +89,7 @@ describe Kartograph::Property do
         child = double('child', cephalopod: 'I will ink you')
         root = double('root', sammy: child)
 
-        expect(top_level.value_for(root)).to eq(cephalopod: child.cephalopod)
+        expect(top_level.value_for(root)).to eq('cephalopod' => child.cephalopod)
       end
 
       context 'when it is plural' do
@@ -104,8 +104,8 @@ describe Kartograph::Property do
           root = double('root', sammy: [child1, child2])
 
           expect(top_level.value_for(root)).to eq([
-            { cephalopod: child1.cephalopod },
-            { cephalopod: child2.cephalopod }
+            { 'cephalopod' => child1.cephalopod },
+            { 'cephalopod' => child2.cephalopod }
           ])
         end
       end


### PR DESCRIPTION
This allows kartograph's artist to draw a hash version of the object being mapped in order to allow additional data to be added to the representation or transformations applied; for example pagination meta data could be added.

cc @phillbaker 