### PR TITLE
Fix duped properties

### DIFF
--- a/lib/kartograph/property.rb
+++ b/lib/kartograph/property.rb
@@ -1,7 +1,6 @@
 module Kartograph
   class Property
-    attr_reader :name, :options
-    attr_accessor :map
+    attr_reader :name, :options, :map
 
     def initialize(name, options = {}, &block)
       @name = name
@@ -24,6 +23,11 @@ module Kartograph
     def key
       @key ||= (options[:key] || name).to_s
       @key
+    end
+
+    def map=(map)
+      @map = map
+      @artist = Artist.new(@map)
     end
 
     def value_for(object, scope = nil)

--- a/lib/kartograph/version.rb
+++ b/lib/kartograph/version.rb
@@ -1,4 +1,4 @@
 module Kartograph
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end
 

--- a/spec/lib/kartograph/property_spec.rb
+++ b/spec/lib/kartograph/property_spec.rb
@@ -231,5 +231,21 @@ describe Kartograph::Property do
       expect(duped.options).to_not be(instance.options)
       expect(duped.options).to eq(instance.options)
     end
+
+    context 'setting the map after duping' do
+      it 'draws a value' do
+        # NOTE: This test is a regression test introduced by caching of Artist instance.
+        dummy_class = Struct.new(:id, :name)
+        dummy = dummy_class.new
+        dummy.id = 123
+
+        instance = Kartograph::Property.new(:id, scopes: [:read])
+        duped = instance.dup
+        duped.map = Kartograph::Map.new
+        val = duped.value_for(dummy)
+
+        expect(val).to_not be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
In v0.2.5 I introduced a bug on duped properties. This patch fixes it.