### PR TITLE
Freeze strings in a memory allocation hotpath.

### DIFF
--- a/lib/kartograph/property.rb
+++ b/lib/kartograph/property.rb
@@ -21,7 +21,7 @@ module Kartograph
     end
 
     def key
-      @key ||= (options[:key] || name).to_s
+      @key ||= (options[:key] || name).to_s.freeze
       @key
     end
 

--- a/lib/kartograph/version.rb
+++ b/lib/kartograph/version.rb
@@ -1,4 +1,4 @@
 module Kartograph
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end
 


### PR DESCRIPTION
According to [1], ruby allocations of strings can hit the GC a lot. This is true for Kartograph
as well. In the allocation test in this codebase, by freezing the strings in one memory hungry
hotpath, the number of allocated objects goes down to ~3k, from ~70k objects.

[1]: https://www.sitepoint.com/ruby-uses-memory/

Before:
![screen shot 2018-02-02 at 3 31 30 pm](https://user-images.githubusercontent.com/33053/35753843-4b74bd5c-082f-11e8-9d30-de8c3b37c029.png)

After:
![screen shot 2018-02-02 at 3 31 33 pm](https://user-images.githubusercontent.com/33053/35753847-4eaebf2c-082f-11e8-9788-786c8f39c9da.png)
