### PR TITLE
ci: add ruby 3.1 and 3.2 to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.5, 2.6, 2.7, '3.0' ]
-    runs-on: ubuntu-latest
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2 ]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
Adds Ruby 3.1 and 3.2 to the test matrix.